### PR TITLE
Delete extraneous backslash in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To start a question, just type `\question`. It will add the text "Question #" wi
 Similarly, if you ever need to skip numbers, you can do
 
 ```tex
-\setcounter{\questionCounter}{<target number - 1>}
+\setcounter{questionCounter}{<target number - 1>}
 ```
 
 So, to skip to the 10th question, `<target number - 1>` = 9.


### PR DESCRIPTION
As per `homework.tex`, `questionCounter` in `\setcounter` does not need a backslash. Including the backslash breaks LaTeX compilation